### PR TITLE
fix jinja 2.11.x compatability issue

### DIFF
--- a/yasha/cli.py
+++ b/yasha/cli.py
@@ -100,7 +100,7 @@ def load_extensions(file):
 
     import jinja2.defaults
     for name, obj in inspect.getmembers(module):
-        if name in jinja2.defaults.__all__:
+        if name in tuple(x for x in dir(jinja2.defaults) if x.isupper()):
             setattr(jinja2.defaults, name, obj)
 
     try:


### PR DESCRIPTION
This is a fix for the breaking compatibility issue introduces in Jinja2 version 2.11.x, as per #60