### PR TITLE
Implement INI and CSV file parsers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,12 +3,22 @@ Version 5.0
 
 Major release, unreleased
 
+- Dropped python2.7 support
 - The option `--keep-trailing-newline` was removed in favor of making
   it default. The old behaviour can be achieved with the new option
   `--remove-trailing-newline`.
+- Fixed jinja 2.11.x compatability issue (gh-60)
+
+Version 4.4
+-----------
+
+Minor release, last release with python2.7 support, unreleased
+
 - Fixed an exit code in case of undefined variable from 0 to 1.
 - Fixed a bug that caused extension classes not to load.
 - Quoted string variable with commas is not converted to list anymore (gh-57).
+- Implemented workaround for jinja 2.11 compatability issue (gh-60)
+- Added support for INI and CSV file parsing
 
 Version 4.3
 -----------

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Options:
   --no-extension-file           Omit template extension file.
   --no-trim-blocks              Load Jinja with trim_blocks=False.
   --no-lstrip-blocks            Load Jinja with lstrip_blocks=False.
-  --remove-trailing-newline     Load Jinja with keep_trailing_newline=False.
+  --keep-trailing-newline       Load Jinja with keep_trailing_newline=True.
   --mode [pedantic|debug]       In pedantic mode Yasha becomes extremely picky
                                 on templates, e.g. undefined variables will
                                 raise an error. In debug mode undefined

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Usage: yasha [OPTIONS] [TEMPLATE_VARIABLES]... TEMPLATE
 Options:
   -o, --output FILENAME         Place the rendered template into FILENAME.
   -v, --variables FILENAME      Read template variables from FILENAME. Built-
-                                in parsers are JSON, YAML, TOML and XML.
+                                in parsers are JSON, YAML, TOML, INI, XML and CSV.
   -e, --extensions FILENAME     Read template extensions from FILENAME. A
                                 Python file is expected.
   -c, --encoding TEXT           Default is UTF-8.
@@ -80,7 +80,7 @@ Options:
 
 ## Template variables
 
-Template variables can be defined in a separate file. By default [JSON](http://www.json.org), [YAML](http://www.yaml.org/start.html), [TOML](https://github.com/toml-lang/toml) and [XML](https://github.com/martinblech/xmltodict) formats are supported.
+Template variables can be defined in a separate file. By default [JSON](http://www.json.org), [YAML](http://www.yaml.org/start.html), [TOML](https://github.com/toml-lang/toml), [INI](https://docs.python.org/3/library/configparser.html#supported-ini-file-structure), [XML](https://github.com/martinblech/xmltodict) and [CSV](https://tools.ietf.org/html/rfc4180#section-2) formats are supported.
 
 ```bash
 yasha -v variables.yaml template.j2
@@ -97,6 +97,58 @@ Additionally you may define variables as part of the command-line call. A variab
 ```bash
 yasha --foo=bar -v variables.yaml template.j2
 ```
+
+### CSV files
+
+to use the data stored in a csv variable file in templates, the name of the variable in the template has to match the name of the csv variable file.
+
+For example, consider the following template and variable files
+
+```
+template.j2
+mydata.csv
+```
+
+And the following contents in `mydata.csv`
+
+```csv
+cell1,cell2,cell3
+cell4,cell5,cell6
+```
+
+to access the rows of cells, you use the following syntax in your template (note that 'mydata' here matches the file name of the csv file)
+
+```jinja2
+{% for row in mydata %}
+cell 1's value is {{row[0]}},
+cell 2's value is {{row[1]}}
+{% endfor %}
+```
+
+By default, each row in the csv file is accessed in the template as a list of values (`row[0]`, `row[1]`, etc). 
+You can make each row accessible instead as a mapping by adding a header to the csv file.
+
+For example, consider the following contents of `mydata.csv`
+
+```csv
+first_column,column2,third column
+cell1,cell2,cell3
+cell4,cell5,cell6
+```
+
+and the following Jinja template
+
+```jinja2
+{% for row in mydata %}
+cell 1's value is {{row.first_column}},
+cell 2's value is {{row.column2}},
+cell 3's value is {{row['third column']}}
+{% endfor %}
+```
+
+As you can see, cells can be accessed by column name instead of column index. 
+If the column name has no spaces in it, the cell can be accessed with 'dotted notation' (ie `row.first_column`) or 'square-bracket notation' (ie `row['third column']`.
+If the column name has a space in it, the cell can only be accessed with 'square-bracket notation'
 
 ### Automatic file variables look up
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "Click",
-        "Jinja2",
+        "Jinja2<2.11",
         "pytoml",
         "pyyaml",
         "xmltodict",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -71,7 +71,7 @@ def testdata(request):
             {% endfor %}"""),
         csv_with_header=wrap("""
             {% for row in data %}
-            cell 1 is {{ row.first_column }}, cell 2 is {{ row.second_column }}
+            cell 1 is {{ row.first_column }}, cell 2 is {{ row['second column'] }}
             {% endfor %}""")
     )
     output = dict(
@@ -175,7 +175,7 @@ def testdata(request):
             templates['csv_with_header'],
             output['csv'],
             wrap("""
-                first_column,second_column
+                first_column,second column
                 value1,2
                 value3,4
                 value5,6

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -428,7 +428,7 @@ COMMENT_END_STRING = '#>'
     ext = tmpdir.join('extensions.py')
     ext.write(extensions)
 
-    out = check_output(('yasha', '-e', str(ext), '-o-', str(tpl)))
+    out = check_output(('yasha', '--keep-trailing-newline', '-e', str(ext), '-o-', str(tpl)))
     assert out.decode() == expected_output
 
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -83,7 +83,7 @@ def test_subprocess_with_unknown_cmd():
     template = '{{ "unknown_cmd" | subprocess }}'
     out, retcode = check_output('yasha', '-', stdin=template)
     assert retcode != 0
-    assert b'unknown_cmd: not found' in out
+    assert b'not found' in out
 
 
 @requires_py3

--- a/yasha/cli.py
+++ b/yasha/cli.py
@@ -139,7 +139,7 @@ def load_extensions(file):
 @click.option("--no-extension-file", is_flag=True, help="Omit template extension file.")
 @click.option("--no-trim-blocks", is_flag=True, help="Load Jinja with trim_blocks=False.")
 @click.option("--no-lstrip-blocks", is_flag=True, help="Load Jinja with lstrip_blocks=False.")
-@click.option("--remove-trailing-newline", is_flag=True, help="Load Jinja with keep_trailing_newline=False.")
+@click.option("--keep-trailing-newline", is_flag=True, help="Load Jinja with keep_trailing_newline=True.")
 @click.option("--mode", type=click.Choice(['pedantic', 'debug']), help="In pedantic mode Yasha becomes extremely picky on templates, e.g. undefined variables will raise an error. In debug mode undefined variables will print as is.")
 @click.option("-M", is_flag=True, help="Outputs Makefile compatible list of dependencies. Doesn't render the template.")
 @click.option("-MD", is_flag=True, help="Creates Makefile compatible .d file alongside the rendered template.")
@@ -147,7 +147,7 @@ def load_extensions(file):
 def cli(
         template_variables, template, output, variables, extensions,
         encoding, include_path, no_variable_file, no_extension_file,
-        no_trim_blocks, no_lstrip_blocks, remove_trailing_newline,
+        no_trim_blocks, no_lstrip_blocks, keep_trailing_newline,
         mode, m, md):
     """Reads the given Jinja TEMPLATE and renders its content
     into a new file. For example, a template called 'foo.c.j2'
@@ -226,7 +226,7 @@ def cli(
         mode=mode,
         trim_blocks=not no_trim_blocks,
         lstrip_blocks=not no_lstrip_blocks,
-        keep_trailing_newline=not remove_trailing_newline
+        keep_trailing_newline=keep_trailing_newline
    )
 
     # Get template

--- a/yasha/parsers.py
+++ b/yasha/parsers.py
@@ -60,6 +60,39 @@ def parse_svd(file):
         "peripherals": svd.peripherals,
     }
 
+
+def parse_ini(file):
+    from configparser import ConfigParser
+    from io import TextIOWrapper
+    cfg = ConfigParser()
+    # yasha opens files in binary mode, configparser expects files in text mode
+    content = file.read().decode(ENCODING)
+    cfg.read_string(content)
+    result = dict(cfg)
+    for section, data in result.items():
+        result[section] = dict(data)
+    return result
+
+
+def parse_csv(file):
+    from csv import reader, DictReader, Sniffer
+    from io import TextIOWrapper
+    from os.path import basename, splitext
+    assert file.name.endswith('.csv')
+    name = splitext(basename(file.name))[0]  # get the filename without the extension
+    content = TextIOWrapper(file, encoding='utf-8', errors='replace')
+    sample = content.read(1024)
+    content.seek(0)
+    csv = list()
+    if Sniffer().has_header(sample):
+        for row in DictReader(content):
+            csv.append(dict(row))
+    else:
+        for row in reader(content):
+            csv.append(row)
+    return {name: csv}
+
+
 PARSERS = {
     '.json': parse_json,
     '.yaml': parse_yaml,
@@ -67,4 +100,6 @@ PARSERS = {
     '.toml': parse_toml,
     '.xml': parse_xml,
     '.svd': parse_svd,
+    '.ini': parse_ini,
+    '.csv': parse_csv
 }


### PR DESCRIPTION
This pull request is a fix / feature-implementation for #54 and #63 

It adds support for parsing ini variable files, and for parsing CSV files as either rows of lists, or rows of dicts, depending on whether or not the CSV file has a header