### PR TITLE
Release 4.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Minor release, last release with python2.7 support, unreleased
 - Quoted string variable with commas is not converted to list anymore (gh-57).
 - Implemented workaround for jinja 2.11 compatability issue (gh-60)
 - Added support for INI and CSV file parsing
+- Fixed a bug that caused Yasha to crash when loading file extensions (regression bug likely caused by Click)
 
 Version 4.3
 -----------

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         "pytoml",
         "pyyaml",
         "xmltodict",
+        'configparser;python_version<"3.5"'
     ],
     entry_points='''
         [console_scripts]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,9 +24,9 @@ THE SOFTWARE.
 
 import pytest
 import os.path
+import sys
 
 SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
-
 
 @pytest.fixture
 def fixtures_dir():

--- a/tests/test_build_automation_c.py
+++ b/tests/test_build_automation_c.py
@@ -28,6 +28,9 @@ from os import path, chdir, mkdir
 
 import pytest
 
+if sys.version_info[0] == 2:
+    FileNotFoundError = IOError
+
 SCRIPT_PATH = path.dirname(path.realpath(__file__))
 
 requires_py27_or_py35_or_greater = pytest.mark.skipif(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,13 +26,18 @@ from os import path, chdir
 import subprocess
 from subprocess import call, check_output
 from textwrap import dedent
+import sys
 
 import pytest
 from yasha.cli import cli
 from click.testing import CliRunner
 
+
 def wrap(text):
     return dedent(text).lstrip()
+
+
+PY2 = True if sys.version_info[0] == 2 else False
 
 
 @pytest.fixture(params=('json', 'yaml', 'yml', 'toml'))
@@ -356,8 +361,8 @@ def test_broken_extensions_name_error(tmpdir):
 
 
 def test_render_template_from_stdin_to_stdout():
-    cmd = r'yasha --foo=bar -'
-    out = check_output(cmd, shell=True, input=b"{{ foo }}")
+    cmd = r'echo {{ foo }} | yasha --foo=bar -'
+    out = check_output(cmd, shell=True)
     assert out == b'bar'
 
 
@@ -374,24 +379,24 @@ def test_json_template(tmpdir):
 
 def test_mode_is_none():
     """gh-42, and gh-44"""
-    cmd = r'yasha -'
-    out = check_output(cmd, shell=True, input=b"{{ foo }}")
+    cmd = r'echo {{ foo }} | yasha -'
+    out = check_output(cmd, shell=True)
     assert out == b''
 
 
 def test_mode_is_pedantic():
     """gh-42, and gh-48"""
     with pytest.raises(subprocess.CalledProcessError) as err:
-        cmd = r'yasha --mode=pedantic -'
-        out = check_output(cmd, shell=True, stderr=subprocess.STDOUT, input=b"{{ foo }}")
+        cmd = r'echo {{ foo }} | yasha --mode=pedantic -'
+        out = check_output(cmd, shell=True, stderr=subprocess.STDOUT)
     out = err.value.output
     assert out == b"Error: Variable 'foo' is undefined\n"
 
 
 def test_mode_is_debug():
     """gh-44"""
-    cmd = r'yasha --mode=debug -'
-    out = check_output(cmd, shell=True, input=b"{{ foo }}")
+    cmd = r'echo {{ foo }} | yasha --mode=debug -'
+    out = check_output(cmd, shell=True)
     assert out == b'{{ foo }}'
 
 

--- a/yasha/cli.py
+++ b/yasha/cli.py
@@ -59,8 +59,10 @@ def load_python_module(file):
         module = loader.load_module()
     except ImportError:  # Fallback to Python2
         import imp
-        desc = (".py", "rb", imp.PY_SOURCE)
-        module = imp.load_module('yasha_extensions', file, file.name, desc)
+        with open(file.name) as f:
+            desc = (".py", "rb", imp.PY_SOURCE)
+            module = imp.load_module('yasha_extensions', f, file.name, desc)
+        pass
     return module
 
 def load_extensions(file):

--- a/yasha/parsers.py
+++ b/yasha/parsers.py
@@ -63,11 +63,7 @@ def parse_svd(file):
 
 
 def parse_ini(file):
-    if sys.version_info[0] == 2:
-        from ConfigParser import ConfigParser
-    else:
-        from configparser import ConfigParser
-    from io import TextIOWrapper
+    from configparser import ConfigParser
     cfg = ConfigParser()
     # yasha opens files in binary mode, configparser expects files in text mode
     content = file.read().decode(ENCODING)

--- a/yasha/parsers.py
+++ b/yasha/parsers.py
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 """
+import sys
 
 from .yasha import ENCODING
 
@@ -62,7 +63,10 @@ def parse_svd(file):
 
 
 def parse_ini(file):
-    from configparser import ConfigParser
+    if sys.version_info[0] == 2:
+        from ConfigParser import ConfigParser
+    else:
+        from configparser import ConfigParser
     from io import TextIOWrapper
     cfg = ConfigParser()
     # yasha opens files in binary mode, configparser expects files in text mode


### PR DESCRIPTION
In preparation for releasing v4.4, I've fixed a few regression bugs causing most of the test failures under python2.7 , and I've also fixed an actual regression bug in the Yasha cli code caused (i think) by a change in the upstream click codebase