### PR TITLE
Fix python literals command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ yasha --lst=foo,bar,baz template.j2
 Note that in case you like to pass a string with commas as a variable you have to quote it as
 
 ```bash
-yasha --str='"foo,bar,baz"' template.j2
+yasha --str="'\"foo,bar,baz\"'" template.j2
 ```
 
 Other possible literals are:


### PR DESCRIPTION
In my day to day deployment I use yasha to render config file. But when I try to pass comma seperated string I found that, comma seperated string can be passed only in following way.