### PR TITLE
Fixed issue with extension inherited classes never getting loaded

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Major release (requires Jinja2>=2.11 and Python>=3.6), unreleased
 - Removed option `--keep-trailing-newline` in favor of keeping the trailing
   newline by default. The old behavior can be achieved with a new option
   `--remove-trailing-newline`.
+- Fixed issue with extension inherited classes never getting loaded.
 
 Version 4.4
 -----------

--- a/yasha/cli.py
+++ b/yasha/cli.py
@@ -72,7 +72,6 @@ def load_extensions(file):
     tests   = dict()
     filters = dict()
     parsers = dict()
-    classes = []
 
     try:
         module = load_python_module(file)
@@ -98,7 +97,7 @@ def load_extensions(file):
                 parsers['.' + name] = attr
         if inspect.isclass(attr):
             if issubclass(attr, Extension):
-                classes.append(attr)
+                CLASSES.append(attr)
 
     import jinja2.defaults
     for name, obj in inspect.getmembers(module):


### PR DESCRIPTION
Hi @kblomqvist 

I tried to create an extension that inherited from `Extensions` yet I couldn't get it to load.
A closer look reveals that we append the class to `classes` list but never update the global `CLASSES`

Not sure what the contribution guidelines are so I forked off of master :)